### PR TITLE
FEATURE ufw

### DIFF
--- a/top.sls
+++ b/top.sls
@@ -4,6 +4,7 @@ base:  # 'base' environment
     - ssh
     - editor
     - users
+    - ufw
 
   '*swarm*':
     - docker

--- a/ufw/README.md
+++ b/ufw/README.md
@@ -1,0 +1,21 @@
+# `ufw` state
+
+## Description
+
+Adds service definitions to UFW and enables some default firewall rules.
+
+## Compatibility
+
+- Debian 9
+
+## Pillars
+
+### `ufw`
+
+Lists all known services
+
+## Data
+
+### `ufw/<service>.ini`
+
+Collection of UFW compatible service definitions

--- a/ufw/README.md
+++ b/ufw/README.md
@@ -6,7 +6,7 @@ Adds service definitions to UFW and enables some default firewall rules.
 
 ## Compatibility
 
-- Debian 9
+- Ubuntu 18.04
 
 ## Pillars
 

--- a/ufw/default_policy.sls
+++ b/ufw/default_policy.sls
@@ -1,15 +1,6 @@
 include:
   - ufw.service
 
-# these are iptables rules which mitigate some common attacks
-/etc/ufw/before.rules:
-  file.managed:
-    - source: salt://ufw/iptables/before.rules
-
-/etc/ufw/before6.rules:
-  file.managed:
-    - source: salt://ufw/iptables/before.rules
-
 'ufw default deny':
   cmd.run
 
@@ -17,8 +8,8 @@ ufw-allow-ssh:
   cmd.run:
     - name: 'ufw allow ssh && ufw limit ssh'
 
-{% if pillar["ufw"]["private_subnets"] %}
-{% for subnet in pillar["ufw"]["private_subnets"] %}
+{% if pillar["ufw"]["trusted_subnets"] %}
+{% for subnet in pillar["ufw"]["trusted_subnets"] %}
 'ufw allow from {{ subnet }}':
   cmd.run:
     - watch:
@@ -26,7 +17,7 @@ ufw-allow-ssh:
 {% endfor %}
 {% endif %}
 
-'ufw enable':
+'yes | ufw enable':
   cmd.run:
     - require:
       - ufw-allow-ssh

--- a/ufw/default_policy.sls
+++ b/ufw/default_policy.sls
@@ -1,0 +1,26 @@
+include:
+  - ufw.service
+
+'ufw enable':
+  cmd.run
+
+# these are iptables rules which mitigate some common attacks
+/etc/ufw/before.rules:
+  file.managed:
+    - source: salt://ufw/iptables/before.rules
+
+/etc/ufw/before6.rules:
+  file.managed:
+    - source: salt://ufw/iptables/before.rules
+
+'ufw default deny':
+  cmd.run:
+    - watch:
+      - service: ufw
+
+{% if pillar["ufw"]["private_subnet"] %}
+'ufw allow from {{ pillar["ufw"]["private_subnet"] }}':
+  cmd.run:
+    - watch:
+      - service: ufw
+{% endif %}

--- a/ufw/default_policy.sls
+++ b/ufw/default_policy.sls
@@ -11,15 +11,11 @@ include:
     - source: salt://ufw/iptables/before.rules
 
 'ufw default deny':
-  cmd.run:
-    - watch:
-      - service: ufw
+  cmd.run
 
 ufw-allow-ssh:
   cmd.run:
     - name: 'ufw allow ssh && ufw limit ssh'
-    - watch:
-      - service: ufw
 
 {% if pillar["ufw"]["private_subnets"] %}
 {% for subnet in pillar["ufw"]["private_subnets"] %}

--- a/ufw/default_policy.sls
+++ b/ufw/default_policy.sls
@@ -17,7 +17,7 @@ ufw-allow-ssh:
 {% endfor %}
 {% endif %}
 
-'yes | ufw enable':
+'ufw enable':
   cmd.run:
     - require:
       - ufw-allow-ssh

--- a/ufw/default_policy.sls
+++ b/ufw/default_policy.sls
@@ -1,9 +1,6 @@
 include:
   - ufw.service
 
-'ufw enable':
-  cmd.run
-
 # these are iptables rules which mitigate some common attacks
 /etc/ufw/before.rules:
   file.managed:
@@ -18,13 +15,9 @@ include:
     - watch:
       - service: ufw
 
-'ufw allow ssh && ufw limit ssh':
+ufw-allow-ssh:
   cmd.run:
-    - watch:
-      - service: ufw
-
-'ufw allow salt-master':
-  cmd.run:
+    - name: 'ufw allow ssh && ufw limit ssh'
     - watch:
       - service: ufw
 
@@ -36,3 +29,8 @@ include:
       - service: ufw
 {% endfor %}
 {% endif %}
+
+'ufw enable':
+  cmd.run:
+    - require:
+      - ufw-allow-ssh

--- a/ufw/default_policy.sls
+++ b/ufw/default_policy.sls
@@ -18,6 +18,23 @@ include:
     - watch:
       - service: ufw
 
+'ufw allow ssh && ufw limit ssh':
+  cmd.run:
+    - watch:
+      - service: ufw
+
+{% if pillar["ufw"]["private_subnet"] %}
+'ufw allow salt from {{ pillar["ufw"]["private_subnet"] }}':
+  cmd.run:
+    - watch:
+      - service: ufw
+{% else %}
+'ufw allow salt':
+  cmd.run:
+    - watch:
+      - service: ufw
+{% endif %}
+
 {% if pillar["ufw"]["private_subnet"] %}
 'ufw allow from {{ pillar["ufw"]["private_subnet"] }}':
   cmd.run:

--- a/ufw/default_policy.sls
+++ b/ufw/default_policy.sls
@@ -23,21 +23,16 @@ include:
     - watch:
       - service: ufw
 
-{% if pillar["ufw"]["private_subnet"] %}
-'ufw allow salt from {{ pillar["ufw"]["private_subnet"] }}':
+'ufw allow salt-master':
   cmd.run:
     - watch:
       - service: ufw
-{% else %}
-'ufw allow salt':
-  cmd.run:
-    - watch:
-      - service: ufw
-{% endif %}
 
-{% if pillar["ufw"]["private_subnet"] %}
-'ufw allow from {{ pillar["ufw"]["private_subnet"] }}':
+{% if pillar["ufw"]["private_subnets"] %}
+{% for subnet in pillar["ufw"]["private_subnets"] %}
+'ufw allow from {{ subnet }}':
   cmd.run:
     - watch:
       - service: ufw
+{% endfor %}
 {% endif %}

--- a/ufw/init.sls
+++ b/ufw/init.sls
@@ -1,0 +1,8 @@
+{% for service in pillar['ufw']['services'] %}
+/etc/ufw/applications.d/{{ service }}.ini:
+  file.managed:
+    - source: salt://ufw/{{ service }}.ini
+    - user: root
+    - group: root
+    - mode: 644
+{% endfor %}

--- a/ufw/init.sls
+++ b/ufw/init.sls
@@ -1,8 +1,4 @@
-{% for service in pillar['ufw']['services'] %}
-/etc/ufw/applications.d/{{ service }}.ini:
-  file.managed:
-    - source: salt://ufw/{{ service }}.ini
-    - user: root
-    - group: root
-    - mode: 644
-{% endfor %}
+include:
+  - ufw.service_definitions
+  - ufw.service
+  - ufw.default_policy

--- a/ufw/service.sls
+++ b/ufw/service.sls
@@ -1,0 +1,7 @@
+ufw:
+  service.running:
+    - enable: True
+    - reload: True
+    - watch:
+      - pkg: ufw
+      - file: /etc/ufw/*

--- a/ufw/service.sls
+++ b/ufw/service.sls
@@ -3,5 +3,4 @@ ufw:
     - enable: True
     - reload: True
     - watch:
-      - pkg: ufw
       - file: /etc/ufw/*

--- a/ufw/service.sls
+++ b/ufw/service.sls
@@ -1,6 +1,5 @@
 ufw:
   service.running:
     - enable: True
-    - reload: True
     - watch:
       - file: /etc/ufw/*

--- a/ufw/service_definitions.sls
+++ b/ufw/service_definitions.sls
@@ -1,0 +1,8 @@
+{% for service in pillar['ufw']['services'] %}
+/etc/ufw/applications.d/{{ service }}.ini:
+  file.managed:
+    - source: salt://ufw/{{ service }}.ini
+    - user: root
+    - group: root
+    - mode: 644
+{% endfor %}


### PR DESCRIPTION
This PR adds a basic ufw configuration.

### Defaults
- All incoming traffic is dropped
- SSH is enabled, but rate limited

### Trusted subnets

You're able to specify a list of trusted subnets in the associated pillar.
All nodes on this subnets may freely communicate with each other.

### Allowing services

States which need to open ports should add a ufw service definition to `data/ufw/`.
You may then enable the service by adding

```
'ufw allow <service>':
  cmd.run
```

to your state.