### PR TITLE
FEATURE Install GlusterFS

### DIFF
--- a/glusterfs/README.md
+++ b/glusterfs/README.md
@@ -1,0 +1,15 @@
+# `glusterfs` state
+
+## Description
+
+A state which installs glusterfs.
+
+## Compatibility
+
+- Ubuntu 18.04
+
+## Pillars
+
+### `glusterfs`
+
+Cluster and hosts configuration

--- a/glusterfs/firewall.sls
+++ b/glusterfs/firewall.sls
@@ -1,0 +1,2 @@
+'ufw allow glusterfs':
+  cmd.run

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -3,7 +3,7 @@
 glusterfs-hosts:
   file.line:
     - name: /etc/hosts
-    - content: '{{ ip_address }} {% for hostname in host["host"] %}{{ hostname }} {% endfor %}'
+    - content: '{{ ip_address }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
     - mode: ensure
     - backup: True
   {% endfor %}

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -1,0 +1,10 @@
+{% for host in pillar["glusterfs"]["hosts"] %}
+  {% for ip_address in host["ip_addresses"] %}
+glusterfs-hosts:
+  file.line:
+    - name: /etc/hosts
+    - content: '{{ ip_address }} {% for hostname in host["host"] %}{{ hostname }} {% endfor %}'
+    - mode: ensure
+    - backup: True
+  {% endfor %}
+{% endfor %}

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -5,4 +5,5 @@ glusterfs-hosts:
     - content: '{{ host["ip_address"] }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
     - mode: ensure
     - backup: True
+    - after: $
 {% endfor %}

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -1,10 +1,8 @@
 {% for host in pillar["glusterfs"]["hosts"] %}
-  {% for ip_address in host["ip_addresses"] %}
 glusterfs-hosts:
   file.line:
     - name: /etc/hosts
-    - content: '{{ ip_address }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
+    - content: '{{ host["ip_address"] }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
     - mode: ensure
     - backup: True
-  {% endfor %}
 {% endfor %}

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -1,6 +1,8 @@
 {% for host in pillar["glusterfs"]["hosts"] %}
+{% if grains["host"] not in host["hostnames"] %}
 glusterfs-host-{{ host["ip_address"] }}:
   host.present:
     - names: {{ host["hostnames"] }}
     - ip: {{ host["ip_address"] }}
+{% endif %}
 {% endfor %}

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -1,3 +1,8 @@
+glusterfs-hosts-workaround:
+  file.append:
+    - name: /etc/hosts
+    - text: "## SALT ANCHOR ##"
+
 {% for host in pillar["glusterfs"]["hosts"] %}
 glusterfs-hosts:
   file.line:
@@ -5,5 +10,7 @@ glusterfs-hosts:
     - content: '{{ host["ip_address"] }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
     - mode: ensure
     - backup: True
-    - after: $
+    - after: "## SALT ANCHOR ##"
+    - require:
+      - glusterfs-hosts-workaround
 {% endfor %}

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -1,6 +1,6 @@
 {% for host in pillar["glusterfs"]["hosts"] %}
 glusterfs-host-{{ host["ip_address"] }}:
-  file.append:
-    - name: /etc/hosts
-    - text: '{{ host["ip_address"] }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
+  host.present:
+    - names: {{ host["hostnames"] }}
+    - ip: {{ host["ip_address"] }}
 {% endfor %}

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -4,7 +4,7 @@ glusterfs-hosts-workaround:
     - text: "## SALT ANCHOR ##"
 
 {% for host in pillar["glusterfs"]["hosts"] %}
-glusterfs-hosts:
+glusterfs-host-{{ host["ip_address"] }}:
   file.line:
     - name: /etc/hosts
     - content: '{{ host["ip_address"] }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -3,6 +3,4 @@ glusterfs-host-{{ host["ip_address"] }}:
   file.append:
     - name: /etc/hosts
     - text: '{{ host["ip_address"] }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
-    - require:
-      - glusterfs-hosts-workaround
 {% endfor %}

--- a/glusterfs/hosts.sls
+++ b/glusterfs/hosts.sls
@@ -1,16 +1,8 @@
-glusterfs-hosts-workaround:
-  file.append:
-    - name: /etc/hosts
-    - text: "## SALT ANCHOR ##"
-
 {% for host in pillar["glusterfs"]["hosts"] %}
 glusterfs-host-{{ host["ip_address"] }}:
-  file.line:
+  file.append:
     - name: /etc/hosts
-    - content: '{{ host["ip_address"] }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
-    - mode: ensure
-    - backup: True
-    - after: "## SALT ANCHOR ##"
+    - text: '{{ host["ip_address"] }} {% for hostname in host["hostnames"] %}{{ hostname }} {% endfor %}'
     - require:
       - glusterfs-hosts-workaround
 {% endfor %}

--- a/glusterfs/init.sls
+++ b/glusterfs/init.sls
@@ -1,3 +1,4 @@
 include:
   - glusterfs.hosts
   - glusterfs.packages
+  - glusterfs.service

--- a/glusterfs/init.sls
+++ b/glusterfs/init.sls
@@ -1,0 +1,3 @@
+include:
+  - glusterfs.hosts
+  

--- a/glusterfs/init.sls
+++ b/glusterfs/init.sls
@@ -2,3 +2,4 @@ include:
   - glusterfs.hosts
   - glusterfs.packages
   - glusterfs.service
+  - glusterfs.firewall

--- a/glusterfs/init.sls
+++ b/glusterfs/init.sls
@@ -1,3 +1,3 @@
 include:
   - glusterfs.hosts
-  
+  - glusterfs.packages

--- a/glusterfs/packages.sls
+++ b/glusterfs/packages.sls
@@ -1,0 +1,18 @@
+python-software-properties:
+  pkg.installed:
+    - refresh: True
+    - prereq:
+      - glusterfs-server-pkg
+
+glusterfs-ppa:
+  pkrepo.managed:
+    - humanname: GlusterFS PPA
+    - name: ppa:gluster/glusterfs-{{ pillar["glusterfs"]["version"] }}
+    - prereq:
+      - glusterfs-server-pkg
+
+glusterfs-server-pkg:
+  pkg.installed:
+    - name: glusterfs-server
+    - refresh: True
+    - hold: True

--- a/glusterfs/packages.sls
+++ b/glusterfs/packages.sls
@@ -8,6 +8,7 @@ glusterfs-ppa:
   pkgrepo.managed:
     - humanname: GlusterFS PPA
     - name: ppa:gluster/glusterfs-{{ pillar["glusterfs"]["version"] }}
+    - key_url: https://download.gluster.org/pub/gluster/glusterfs/LATEST/rsa.pub
     - prereq:
       - glusterfs-server-pkg
 

--- a/glusterfs/packages.sls
+++ b/glusterfs/packages.sls
@@ -1,4 +1,4 @@
-python-software-properties:
+software-properties-common:
   pkg.installed:
     - refresh: True
     - prereq:

--- a/glusterfs/packages.sls
+++ b/glusterfs/packages.sls
@@ -5,7 +5,7 @@ software-properties-common:
       - glusterfs-server-pkg
 
 glusterfs-ppa:
-  pkrepo.managed:
+  pkgrepo.managed:
     - humanname: GlusterFS PPA
     - name: ppa:gluster/glusterfs-{{ pillar["glusterfs"]["version"] }}
     - prereq:

--- a/glusterfs/packages.sls
+++ b/glusterfs/packages.sls
@@ -8,7 +8,7 @@ glusterfs-ppa:
   pkgrepo.managed:
     - humanname: GlusterFS PPA
     - name: ppa:gluster/glusterfs-{{ pillar["glusterfs"]["version"] }}
-    - key_url: https://download.gluster.org/pub/gluster/glusterfs/LATEST/rsa.pub
+    - key_url: https://download.gluster.org/pub/gluster/glusterfs/{{ pillar["glusterfs"]["version"] }}/rsa.pub
     - prereq:
       - glusterfs-server-pkg
 

--- a/glusterfs/service.sls
+++ b/glusterfs/service.sls
@@ -1,0 +1,10 @@
+include:
+  - glusterfs.packages
+
+glusterd:
+  service.running:
+    - enable: True
+    - require:
+      - glusterfs-server-pkg
+    - watch:
+      - glusterfs-server-pkg

--- a/top.sls
+++ b/top.sls
@@ -5,6 +5,7 @@ base:  # 'base' environment
     - editor
     - users
     - ufw
+    - glusterfs
 
   '*swarm*':
     - docker


### PR DESCRIPTION
This PR adds the functionality of installing GlusterFS to a set of nodes.

Peering and volume creation are not automated, this just install the required software and configures firewall and `/etc/hosts` to allow peering.